### PR TITLE
Apply clear_threshold to semantic segmentation map too

### DIFF
--- a/src/extras.py
+++ b/src/extras.py
@@ -31,9 +31,10 @@ def segmentation_mask(cloud,shadow=None,thin_range=(0.1,0.1),shadow_threshold=0.
     seg_mask=torch.zeros(b,h,w)
     
     # get binary representations
-    cloud[cloud < clear_threshold] = 0.0
-    thick_cloud_b=1.0*(cloud.mean(-3)>=thin_range[1])
-    thin_cloud_b=1.0*(cloud.mean(-3)<thin_range[1])*(cloud.mean(-3)>=thin_range[0])*(1.0-thick_cloud_b)
+    cloud_copy = cloud.detach().clone()
+    cloud_copy[cloud_copy < clear_threshold] = 0.0
+    thick_cloud_b=1.0*(cloud_copy.mean(-3)>=thin_range[1])
+    thin_cloud_b=1.0*(cloud_copy.mean(-3)<thin_range[1])*(cloud_copy.mean(-3)>=thin_range[0])*(1.0-thick_cloud_b)
     shadow_b=1.0*(shadow.mean(-3)>shadow_threshold)*(1.0-thick_cloud_b)*(1.0-thin_cloud_b)
 
     if thin_range[0]==thin_range[1]:

--- a/src/extras.py
+++ b/src/extras.py
@@ -1,7 +1,7 @@
 import torch
 
 
-def segmentation_mask(cloud,shadow=None,thin_range=(0.1,0.1),shadow_threshold=0.1):
+def segmentation_mask(cloud,shadow=None,thin_range=(0.1,0.1),shadow_threshold=0.1, clear_threshold=0.0):):
     """ The following encoding method is used:
     0: Cleary Sky
     1: Cloud
@@ -31,6 +31,7 @@ def segmentation_mask(cloud,shadow=None,thin_range=(0.1,0.1),shadow_threshold=0.
     seg_mask=torch.zeros(b,h,w)
     
     # get binary representations
+    cloud[cloud < clear_threshold] = 0.0
     thick_cloud_b=1.0*(cloud.mean(-3)>=thin_range[1])
     thin_cloud_b=1.0*(cloud.mean(-3)<thin_range[1])*(cloud.mean(-3)>=thin_range[0])*(1.0-thick_cloud_b)
     shadow_b=1.0*(shadow.mean(-3)>shadow_threshold)*(1.0-thick_cloud_b)*(1.0-thin_cloud_b)


### PR DESCRIPTION
Hi, thanks a lot for implementing SatelliteCloudGenerator! :)

While using it I noticed that, when applying synthetic clouds, the clear_threshold is applied correctly to the final generated image, but it is not correctly applied to the segmentation mask.

With this commit the segmentation mask is updated accordingly